### PR TITLE
Moved distrobox out of AUR packages

### DIFF
--- a/Arch-Linux/Gnome.md
+++ b/Arch-Linux/Gnome.md
@@ -89,8 +89,8 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
-yay -S arch-update distrobox gnome-browser-connector gnome-terminal-transparency onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
+sudo pacman -S discord distrobox dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+yay -S arch-update gnome-browser-connector gnome-terminal-transparency onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services

--- a/Arch-Linux/IceWM.md
+++ b/Arch-Linux/IceWM.md
@@ -128,8 +128,8 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
-yay -S arch-update distrobox onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
+sudo pacman -S discord distrobox dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services

--- a/Arch-Linux/XFCE.md
+++ b/Arch-Linux/XFCE.md
@@ -87,8 +87,8 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
-yay -S arch-update distrobox lightdm-webkit2-theme-glorious mugshot onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
+sudo pacman -S discord distrobox dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+yay -S arch-update lightdm-webkit2-theme-glorious mugshot onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -128,8 +128,8 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
-yay -S arch-update distrobox onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
+sudo pacman -S discord distrobox dmenu docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services

--- a/WSL/Arch-Linux-WSL.md
+++ b/WSL/Arch-Linux-WSL.md
@@ -50,12 +50,12 @@ sudo vi /etc/pacman.conf
 
 ```
 sudo pacman -Syu #Update our system
-sudo pacman -S base-devel linux-headers man bash-completion openssh inetutils dnsutils traceroute rsync zip unzip cronie diffutils git tmux mlocate htop neofetch glow docker #Install my needed packages. DO NOT INSTALL "fakeroot" (https://github.com/yuk7/ArchWSL/issues/3)
+sudo pacman -S base-devel linux-headers man bash-completion openssh inetutils dnsutils traceroute rsync zip unzip cronie diffutils git tmux mlocate htop neofetch glow docker distrobox #Install my needed packages. DO NOT INSTALL "fakeroot" (https://github.com/yuk7/ArchWSL/issues/3)
 cd /tmp #Change directory to tmp to download and install AUR support
 git clone https://aur.archlinux.org/yay.git #Download "yay" install sources
 cd yay #Change directory to "yay" install sources directory
 makepkg -si #Install "yay"
-yay -S ddgr certificate-ripper-bin distrobox #Install "ddgr", "certificate-ripper" and "distrobox"
+yay -S ddgr certificate-ripper-bin #Install "ddgr" and "certificate-ripper"
 sudo systemctl enable --now cronie docker #Enable systemd services
 ```
   


### PR DESCRIPTION
I've moved `distrobox` from the AUR to the Arch's [community] repo.
This PR serves to update my installation procedures accordingly.