### PR TITLE
Switch xclip from a dependency to explicitly installed

### DIFF
--- a/Arch-Linux/Gnome.md
+++ b/Arch-Linux/Gnome.md
@@ -80,9 +80,9 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update gnome-browser-connector gnome-terminal-transparency onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
-sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
+sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services
 ```

--- a/Arch-Linux/IceWM.md
+++ b/Arch-Linux/IceWM.md
@@ -119,9 +119,9 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g rofi steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g rofi steam thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
-sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
+sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services
 ```

--- a/Arch-Linux/XFCE.md
+++ b/Arch-Linux/XFCE.md
@@ -78,9 +78,9 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g steam thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update lightdm-webkit2-theme-glorious mugshot onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
-sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
+sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services
 ```

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -119,9 +119,9 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g rofi steam thunderbird tmux virt-viewer vlc zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch ntfs-3g rofi steam thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify systray-x-git timeshift ventoy-bin zaman #Main packages from the AUR
-sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xclip xdg-utils #Optional dependencies that I need for the above packages
+sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers
 sudo systemctl enable --now docker cronie #Start and enable associated services
 ```


### PR DESCRIPTION
I initially installed `xclip` as a optional dependency of `keepassxc` but I use it explicitly in my `tmux` config so I decided to make it explicitly installed to avoid removing it as an orphan package by accident.