### PR TITLE
Remove 'dev' related packages

### DIFF
--- a/Arch-Linux/Gnome.md
+++ b/Arch-Linux/Gnome.md
@@ -80,7 +80,7 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S codespell discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update gnome-browser-connector gnome-terminal-transparency onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/IceWM.md
+++ b/Arch-Linux/IceWM.md
@@ -119,7 +119,7 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S codespell discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/XFCE.md
+++ b/Arch-Linux/XFCE.md
@@ -78,7 +78,7 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S codespell discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update lightdm-webkit2-theme-glorious mugshot onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -119,7 +119,7 @@ sudo vim /etc/fstab
 
 - Main packages:
 ```
-sudo pacman -S codespell discord distrobox docker firefox glow hexchat htop hugo keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux virt-viewer vlc xclip zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Gentoo/i3.md
+++ b/Gentoo/i3.md
@@ -76,7 +76,6 @@ sudo vim /etc/fstab
 To enable flathub repo:  
 `flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`  
   
-- codespell
 - discord-bin
 - app-containers/docker --> `sudo systemctl enable --now docker`
 - distrobox --> `echo "app-containers/distrobox ~amd64" | sudo tee /etc/portage/package.accept_keywords/distrobox`
@@ -104,7 +103,6 @@ To enable flathub repo:
 - zathura-pdf-poppler
 - mlocate
 - htop
-- hugo
 - neofetch
 - wireguard-tools **Only for my Laptop in order to connect to my VPN**
 - zaman --> https://github.com/Antiz96/zaman


### PR DESCRIPTION
This PR aims to remove package related to "dev" stuff, as I don't use them too often.
I'll move and use those packages in a container as of now.