### PR TITLE
Switch the power menu to a Rofi menu script

### DIFF
--- a/Arch-Linux/Gnome.md
+++ b/Arch-Linux/Gnome.md
@@ -83,7 +83,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux ttf-font-awesome virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update gnome-browser-connector gnome-terminal-transparency onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/IceWM.md
+++ b/Arch-Linux/IceWM.md
@@ -122,7 +122,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux ttf-font-awesome virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/XFCE.md
+++ b/Arch-Linux/XFCE.md
@@ -81,7 +81,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g steam systray-x thunderbird tmux ttf-font-awesome virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update lightdm-webkit2-theme-glorious mugshot onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts rofi ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -122,7 +122,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S discord distrobox docker firefox glow hexchat htop keepassxc mlocate neofetch noto-fonts-emoji ntfs-3g rofi steam systray-x thunderbird tmux ttf-font-awesome virt-viewer vlc xclip xorg-xhost zathura zathura-pdf-poppler #Main packages from Arch repos
 yay -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin spotify timeshift ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer #Start and enable associated timers

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -159,7 +159,7 @@ git clone https://github.com/speedenator/agnoster-bash.git .bash/themes/agnoster
 ## Dotfiles
 
 ```bash
-mkdir -p ~/.config/i3 && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/i3-config -o ~/.config/i3/config && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/lock.png -o ~/.config/i3/lock.png && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/wallpaper.jpg -o ~/.config/i3/wallpaper.jpg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/shutdown.svg -o ~/.config/i3/shutdown.svg
+mkdir -p ~/.config/i3 && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/i3-config -o ~/.config/i3/config && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/lock.png -o ~/.config/i3/lock.png && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/wallpaper.jpg -o ~/.config/i3/wallpaper.jpg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/shutdown.svg -o ~/.config/i3/shutdown.svg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/power-menu.sh -o ~/.config/i3/power-menu.sh && chmod +x ~/.config/i3/power-menu.sh
 mkdir -p ~/.config/tint2 && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/Arch_Taskbar.png -o ~/.config/tint2/Arch_Taskbar.png && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/caffeine-cup-empty.svg -o ~/.config/tint2/caffeine-cup-empty.svg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/caffeine-cup-full.svg -o ~/.config/tint2/caffeine-cup-full.svg && cp -f ~/.config/tint2/caffeine-cup-empty.svg ~/.config/tint2/autolock.svg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/tint2rc -o ~/.config/tint2/tint2rc
 curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/Bashrc/Arch -o ~/.bashrc
 mkdir -p ~/.config/tmux/ && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/General/tmux.conf -o ~/.config/tmux/tmux.conf
@@ -222,4 +222,5 @@ sudo vi /etc/pulse/default.pa
 - Super + F5 = Switch to workspace5
 - Super + F6 = Switch to workspace6
 - Super + Tab = Switch to next workspace
+- Alt + Tab = Open the window switcher
 - Super + Esc = Open the power menu

--- a/Dotfiles/i3/i3-config
+++ b/Dotfiles/i3/i3-config
@@ -241,6 +241,9 @@ gaps inner 10
 #Open app finder
 bindsym $mod+a exec rofi -show drun -show-icons
 
+#Open power menu
+bindsym $mod+Escape exec ~/.config/i3/power-menu.sh
+
 #Open window switcher
 bindsym Mod1+Tab exec rofi -show window -show-icons
 
@@ -297,21 +300,6 @@ bindsym $mod+F6 workspace number $ws6
 
 #Switch to next workspace
 bindsym $mod+Tab workspace next
-
-#Open the power menu
-set $power_menu [L]ock | [H]alt | [R]eboot | [S]hutdown
-mode "$power_menu" {
-        bindsym l exec --no-startup-id i3lock -eti ~/.config/i3/lock.png && kill $(pidof notification-daemon) && /usr/lib/notification-daemon-1.0/notification-daemon, mode "default"
-        bindsym h exec --no-startup-id i3lock -eti ~/.config/i3/lock.png && test -e /run/systemd/system && systemctl suspend && kill $(pidof notification-daemon) && /usr/lib/notification-daemon-1.0/notification-daemon, mode "default"
-        bindsym r exec --no-startup-id test -e /run/systemd/system && systemctl reboot, mode "default"
-        bindsym s exec --no-startup-id test -e /run/systemd/system && systemctl poweroff, mode "default"
-
-        #Back to normal: Enter or Escape
-        bindsym Return mode "default" ; exec kill $(pidof notification-daemon) && /usr/lib/notification-daemon-1.0/notification-daemon
-        bindsym Escape mode "default" ; exec kill $(pidof notification-daemon) && /usr/lib/notification-daemon-1.0/notification-daemon
-}
-
-bindsym $mod+Escape mode "$power_menu" ; exec notify-send -u critical -t 0 -i ~/.config/i3/shutdown.svg "Power menu" "[L]ock\n[H]alt\n[R]eboot\n[S]hutdown"
 
 #Multimedia go to previous
 bindsym F7 exec playerctl previous

--- a/Dotfiles/i3/power-menu.sh
+++ b/Dotfiles/i3/power-menu.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+options=("<span font='FontAwesome'></span> Lock" "<span font='FontAwesome'></span> Suspend" "<span font='FontAwesome'></span> Soft Reboot" "<span font='FontAwesome'></span> Reboot" "<span font='FontAwesome'></span> Shutdown")
+rofi_menu_options=$(for option in "${options[@]}"; do echo "${option}"; done | rofi -dmenu -i -markup-rows -p "Power menu")
+
+case "${rofi_menu_options}" in
+	*Lock)
+		i3lock -eti ~/.config/i3/lock.png
+	;;
+	*Suspend)
+		i3lock -eti ~/.config/i3/lock.png && systemctl suspend 
+	;;
+	*Soft\ Reboot)
+		systemctl soft-reboot
+	;;
+	*Reboot)
+		systemctl reboot
+	;;
+	*Shutdown)
+		systemctl poweroff
+	;;
+esac

--- a/Gentoo/i3.md
+++ b/Gentoo/i3.md
@@ -99,6 +99,7 @@ To enable flathub repo: `flatpak remote-add --if-not-exists flathub https://flat
 - virt-viewer
 - isoimagewriter
 - tmux
+- ttf-font-awesome
 - rofi
 - noto-emoji
 - zathura

--- a/Gentoo/i3.md
+++ b/Gentoo/i3.md
@@ -135,7 +135,7 @@ git clone https://github.com/speedenator/agnoster-bash.git .bash/themes/agnoster
 ### i3 configuration
 
 ```bash
-mkdir -p ~/.config/i3 && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/i3-config -o ~/.config/i3/config && sed -i s/firefox/firefox-bin/g ~/.config/i3/config && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/lock.png -o ~/.config/i3/lock.png && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/wallpaper.jpg -o ~/.config/i3/wallpaper.jpg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/shutdown.svg -o ~/.config/i3/shutdown.svg
+mkdir -p ~/.config/i3 && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/i3-config -o ~/.config/i3/config && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/lock.png -o ~/.config/i3/lock.png && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/wallpaper.jpg -o ~/.config/i3/wallpaper.jpg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/shutdown.svg -o ~/.config/i3/shutdown.svg && curl https://raw.githubusercontent.com/Antiz96/Linux-Desktop/main/Dotfiles/i3/power-menu.sh -o ~/.config/i3/power-menu.sh && chmod +x ~/.config/i3/power-menu.sh
 ```
 
 ### Tint2 configuration
@@ -200,6 +200,7 @@ sudo vi /etc/pulse/default.pa
 - Super + Shift + Left = Move focused window to the left (when reaching the edge of the screen, makes the window move to the left screen if there's one)
 - Super + Shift + Up = Move focused window up (when reaching the edge of the screen, makes the window move to the up screen if there's one)
 - Super + Shift + Down = Move focused window down (when reaching the edge of the screen, makes the window move to the down screen if there's one)
+- Alt + Tab = Open the window switcher
 - Super + Esc = Open the power menu
 - Super + F1 = Switch to workspace1
 - Super + F2 = Switch to workspace2


### PR DESCRIPTION
 The power menu was initially handled by an i3 mode a basic `notify-send` notification.

As effective as it was, this method isn't user friendly and also "insecure" (in the sense that it sometimes wasn't so clear that you were in the power menu mode, which could lead to accidental suspend/reboot/shutdown).

The power menu is now handled via a simple bash script that spawns a rofi menu displaying the available options (lock, suspend, reboot...).
This is way more user friendly (search through options, mouse support, etc...) and more "secure" (as it is now clear that you opened the power menu, preventing accidental/undesired actions).

This new power menu also adds an option for the new [systemctl soft-reboot](https://lemm.ee/post/2464821) command.