### PR TITLE
Replace gnome-calculator by speedcrunch

### DIFF
--- a/Arch-Linux/IceWM.md
+++ b/Arch-Linux/IceWM.md
@@ -26,7 +26,7 @@ Still a very minimal installation though.
 - For regular computers:
 
 ```bash
-sudo pacman -S icewm xfce4-terminal polkit-gnome pulseaudio picom plank thunar thunar-archive-plugin file-roller gvfs xdg-user-dirs-gtk mousepad ristretto flameshot notification-daemon gnome-calculator network-manager-applet blueman redshift openssh xorg-xinit xorg-xrandr xautolock i3lock lxappearance numlockx playerctl gsimplecal
+sudo pacman -S icewm xfce4-terminal polkit-gnome pulseaudio picom plank thunar thunar-archive-plugin file-roller gvfs xdg-user-dirs-gtk mousepad ristretto flameshot notification-daemon speedcrunch network-manager-applet blueman redshift openssh xorg-xinit xorg-xrandr xautolock i3lock lxappearance numlockx playerctl gsimplecal
 sudo localectl --no-convert set-x11-keymap fr #Configure Keyboard layout for x11
 ```
 

--- a/Arch-Linux/XFCE.md
+++ b/Arch-Linux/XFCE.md
@@ -25,7 +25,7 @@ Check <https://archlinux.org/groups/x86_64/xfce4/> & <https://archlinux.org/grou
 If you want a complete XFCE installation, just install the "xfce4" and the "xfce4-goodies" packages (additionally you may need a display manager).
 
 ```bash
-sudo pacman -S xfce4 mousepad ristretto thunar-archive-plugin xfce4-notifyd xfce4-screenshooter xfce4-screensaver xfce4-pulseaudio-plugin xfce4-whiskermenu-plugin numlockx plank gvfs gnome-calculator network-manager-applet blueman redshift file-roller picom xdg-user-dirs-gtk pulseaudio openssh lightdm lightdm-gtk-greeter
+sudo pacman -S xfce4 mousepad ristretto thunar-archive-plugin xfce4-notifyd xfce4-screenshooter xfce4-screensaver xfce4-pulseaudio-plugin xfce4-whiskermenu-plugin numlockx plank gvfs speedcrunch network-manager-applet blueman redshift file-roller picom xdg-user-dirs-gtk pulseaudio openssh lightdm lightdm-gtk-greeter
 sudo systemctl enable lightdm
 sudo localectl --no-convert set-x11-keymap fr #Configure Keyboard layout for x11
 ```
@@ -195,7 +195,7 @@ source ~/.bashrc
 - Super + F = Switch size of windows (Maximize/Minimize)
 - Super + D = Close the window
 - Super + E = thunar
-- Super + C = calculator --> gnome-calculator
+- Super + C = calculator --> speedcrunch
 - Super + M = Display the desktop
 - Super + T = Terminal
 - Super + L = Lock the screen --> dm-tool switch-to-greeter

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -26,7 +26,7 @@ Still a very minimal installation though.
 - For regular computers:
 
 ```bash
-sudo pacman -S i3-wm xfce4-terminal polkit-gnome pulseaudio picom thunar thunar-archive-plugin file-roller gvfs xdg-user-dirs mousepad ristretto flameshot notification-daemon gnome-calculator network-manager-applet blueman redshift openssh xorg-xinit xorg-xrandr xautolock i3lock lxappearance numlockx playerctl gsimplecal tint2 feh
+sudo pacman -S i3-wm xfce4-terminal polkit-gnome pulseaudio picom thunar thunar-archive-plugin file-roller gvfs xdg-user-dirs mousepad ristretto flameshot notification-daemon speedcrunch network-manager-applet blueman redshift openssh xorg-xinit xorg-xrandr xautolock i3lock lxappearance numlockx playerctl gsimplecal tint2 feh
 sudo localectl --no-convert set-x11-keymap fr #Configure Keyboard layout for x11
 ```
 

--- a/Dotfiles/i3/i3-config
+++ b/Dotfiles/i3/i3-config
@@ -262,14 +262,14 @@ bindsym $mod+s sticky toggle
 #Close active window
 bindsym $mod+d kill
 
-#Launch file manager (thunar)
+#Launch file manager
 bindsym $mod+e exec thunar
 
-#Launch notepad (mousepad)
+#Launch notepad
 bindsym $mod+m exec mousepad
 
-#Launch calculator (gnome-calculator)
-bindsym $mod+c exec gnome-calculator
+#Launch calculator
+bindsym $mod+c exec speedcrunch
 
 #Open terminal
 bindsym $mod+t exec xfce4-terminal

--- a/Gentoo/i3.md
+++ b/Gentoo/i3.md
@@ -12,7 +12,7 @@ i3 with a few extra packages according to my personal preferences.
 Still a very minimal installation though.
 
 ```bash
-sudo env USE="minimal" emerge --ask i3 xfce4-terminal polkit-gnome pulseaudio picom thunar thunar-archive-plugin file-roller gvfs xdg-user-dirs mousepad ristretto flameshot notification-daemon gnome-calculator nm-applet blueman redshift openssh xinit xrandr xautolock i3lock lxappearance numlockx playerctl tint2 feh
+sudo env USE="minimal" emerge --ask i3 xfce4-terminal polkit-gnome pulseaudio picom thunar thunar-archive-plugin file-roller gvfs xdg-user-dirs mousepad ristretto flameshot notification-daemon speedcrunch nm-applet blueman redshift openssh xinit xrandr xautolock i3lock lxappearance numlockx playerctl tint2 feh
 sudo localectl --no-convert set-x11-keymap fr #Configure Keyboard layout for x11
 ```
 


### PR DESCRIPTION
gnome-calculator became 'heavier' (in terms of dependencies) and more and more complete over time. Since I'm only using a calculator on some rare occasions and for some very simple maths, I might switch to a simpler calculator package that will fit my simple needs perfectly.

https://archlinux.org/packages/?name=speedcrunch