### PR TITLE
No need to uncomment the HookDir parameter in pacman.conf

### DIFF
--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -78,8 +78,6 @@ vim /etc/pacman.conf #Enable the "color" and "parallel downloads" options in pac
 ```
 
 > [...]  
-> HookDir     = /etc/pacman.d/hooks/  
-> [...]  
 > Color  
 > [...]  
 > ParallelDownloads = 10  

--- a/Arch-Linux/Base_installation_with_disk_encryption.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption.md
@@ -81,8 +81,6 @@ vim /etc/pacman.conf #Enable the "color" and "parallel downloads" options in pac
 ```
 
 > [...]  
-> HookDir     = /etc/pacman.d/hooks/  
-> [...]  
 > Color  
 > [...]  
 > ParallelDownloads = 10  


### PR DESCRIPTION
The default value is already applied. Uncommenting the parameter is only necessary if you want to use a different path.