### PR TITLE
Increase ESP size to 1G

### DIFF
--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -19,7 +19,7 @@ fdisk -l #Check the hard drives' name to select the one I want to install Arch L
 
 ### Partition scheme
 
-> EFI partition mounted on /boot/EFI --> 550M - FAT32  
+> EFI partition mounted on /boot/EFI --> 1G - FAT32  
 > Swap partition --> 4G - SWAP (<https://itsfoss.com/swap-size>)  
 > Root partition mounted on / --> Left free space - EXT4
 
@@ -32,7 +32,7 @@ fdisk /dev/nvme0n1 #Partitioning the disk I want to install Arch on
 > Delete current partitions ---> **o** (This deletes every partitions, use the "d" option instead if you only want to delete specific partitions)  
 > Create a GPT partition table (cause I use EFI) ---> **g**
 >
-> Create a 550M EFI partition ---> **n** ---> **+550M** as last sector  
+> Create a 1G EFI partition ---> **n** ---> **+1G** as last sector  
 > Create a 4G Swap partition ---> **n** ---> **+4G** as last sector  
 > Create a Root partition with the left space ---> **n**
 >

--- a/Arch-Linux/Base_installation_with_disk_encryption.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption.md
@@ -20,7 +20,7 @@ fdisk -l #Check the hard drives' name to select the one I want to install Arch L
 
 ### Partition scheme
 
-> EFI partition mounted on /boot --> 550M - FAT32  
+> EFI partition mounted on /boot --> 1G - FAT32  
 > Swap partition --> 4G - SWAP (<https://itsfoss.com/swap-size>)  
 > Root partition mounted on / --> Left free space - EXT4
 
@@ -33,7 +33,7 @@ fdisk /dev/nvme0n1 #Partitioning the disk I want to install Arch on
 > Delete current partitions ---> **o** (This deletes every partitions, use the "d" option instead if you only want to delete specific partitions)  
 > Create a GPT partition table (cause I use EFI) ---> **g**  
 >
-> Create a 550M EFI partition ---> **n** ---> **+550M** as last sector  
+> Create a 1G EFI partition ---> **n** ---> **+1G** as last sector  
 > Create a 4G Swap partition ---> **n** ---> **+4G** as last sector  
 > Create a Root partition with the left space ---> **n**  
 >

--- a/Gentoo/Base_installation.md
+++ b/Gentoo/Base_installation.md
@@ -20,7 +20,7 @@ rc-service sshd start #And then connect from another computer via ssh
 fdisk /dev/sda
 ```
 
-> 550M --> EFI  
+> 1G --> EFI  
 > 4G --> SWAP  
 > Left --> ROOT
 


### PR DESCRIPTION
Nowadays, there's no point keeping the ESP small (in terms of size). With disk space non being a constraint anymore, it's just a potential risk to expose yourself to problems in case of eventual bugs (e.g. https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/issues/238) or simply because things gets bigger with time.

Switching to a 1G ESP doesn't represente a hugo cost and is safer