### PR TITLE
Remove the ykcs11 package

### DIFF
--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -123,7 +123,7 @@ sudo vim /etc/fstab
 
 ```bash
 sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail hexchat htop keepassxc mlocate mpv noto-fonts-emoji ntfs-3g powerline-fonts rofi steam systray-x thunderbird timeshift tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
-paru -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin ventoy-bin ykcs11-p11-kit-module zaman #Main packages from the AUR
+paru -S arch-update onlyoffice-bin pa-applet-git protonmail-bridge-bin ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service #Start and enable timers and services
 sudo systemctl enable --now docker cronie pcscd #Start and enable services


### PR DESCRIPTION
Not needed anymore as the module is now included in yubico-piv-tool