### PR TITLE
Make paru autobuild packages in a clean chroot

### DIFF
--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -157,7 +157,7 @@ reboot #Reboot the computer to boot into the fresh Arch install
 ## Log in with the "regular" user previously created and install additional useful packages
 
 ```bash
-sudo pacman -S base-devel man bash-completion intel-ucode pacman-contrib #Additional useful packages and drivers. Install "amd-ucode" instead of "intel-ucode" if you have an AMD CPU
+sudo pacman -S devtools man bash-completion intel-ucode pacman-contrib #Additional useful packages and drivers. Install "amd-ucode" instead of "intel-ucode" if you have an AMD CPU
 sudo grub-mkconfig -o /boot/grub/grub.cfg #Re-generate Grub configuration to include CPU microcode
 ```
 

--- a/Arch-Linux/Base_installation_with_disk_encryption.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption.md
@@ -186,7 +186,7 @@ reboot #Reboot the computer to boot into the fresh Arch install
 ## Log in with the "regular" user previously created and install additional useful packages
 
 ```bash
-sudo pacman -S base-devel man bash-completion intel-ucode pacman-contrib #Additional useful packages and drivers. Install "amd-ucode" instead of "intel-ucode" if you have an AMD CPU
+sudo pacman -S devtools man bash-completion intel-ucode pacman-contrib #Additional useful packages and drivers. Install "amd-ucode" instead of "intel-ucode" if you have an AMD CPU
 sudo grub-mkconfig -o /boot/grub/grub.cfg #Re-generate Grub configuration to include CPU microcode
 ```
 

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -84,7 +84,8 @@ sudo pacman -S git
 cd /tmp
 git clone https://aur.archlinux.org/paru.git
 cd paru
-makepkg -si
+pkgctl build --repo extra
+sudo pacman -U paru-!(*debug*).pkg.tar.zst
 ```
 
 ## Enable multilib repo in pacman.conf

--- a/Dotfiles/General/paru.conf
+++ b/Dotfiles/General/paru.conf
@@ -1,2 +1,3 @@
 [options]
 AurOnly
+Chroot


### PR DESCRIPTION
This is cleaner and allow me to get rid of the base-devel metapkg on my host system. I need devtools/pkgctl to package stuff on Arch repos anyway.