### PR TITLE
Update Secure Boot setup

### DIFF
--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -334,7 +334,7 @@ sudo sbctl enroll-keys -m # Enroll our keys to the UEFI, including Microsoft's k
 sudo sbctl sign -s /boot/EFI/Linux/arch-linux.efi # Sign the UKI
 sudo sbctl sign -s /boot/EFI/Linux/arch-linux-fallback.efi # Sign the fallback UKI
 sudo sbctl sign -s /boot/EFI/systemd/systemd-bootx64.efi # Sign systemd-boot boot loader
-sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi # Sign systemd-boot boot loader under /usr/lib (required when using the `systemd-boot-update.service`. See the "Tip" at https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Automatic_signing_with_the_pacman_hook
+sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi # Sign systemd-boot boot loader under /usr/lib (required when using the `systemd-boot-update.service`. See the "Tip" at https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Automatic_signing_with_the_pacman_hook)
 sudo sbctl sign -s /boot/EFI/BOOT/BOOTX64.EFI # Sign the fallback boot loader
 sudo sbctl sign -s /boot/vmlinuz-linux # Sign the kernel file. This is not necessary as we boot the UKI instead, but it also doesn't hurt.
 sudo sbctl verify # Verify that the above files have been correctly signed

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -333,9 +333,11 @@ sudo sbctl create-keys # Generate our own signing keys
 sudo sbctl enroll-keys -m # Enroll our keys to the UEFI, including Microsoft's keys (`-m`). See the warning in the following URL for more details: https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Creating_and_enrolling_keys
 sudo sbctl sign -s /boot/EFI/Linux/arch-linux.efi # Sign the UKI
 sudo sbctl sign -s /boot/EFI/Linux/arch-linux-fallback.efi # Sign the fallback UKI
-sudo sbctl sign -s /boot/EFI/BOOT/BOOTX64.EFI # Sign the boot loader
-sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi # Sign systemd-boot boot loader
-sudo sbctl verify # Verify that the above files have been correctly sign
+sudo sbctl sign -s /boot/EFI/systemd/systemd-bootx64.efi # Sign systemd-boot boot loader
+sudo sbctl sign -s -o /usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed /usr/lib/systemd/boot/efi/systemd-bootx64.efi # Sign systemd-boot boot loader under /usr/lib (required when using the `systemd-boot-update.service`. See the "Tip" at https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Automatic_signing_with_the_pacman_hook
+sudo sbctl sign -s /boot/EFI/BOOT/BOOTX64.EFI # Sign the fallback boot loader
+sudo sbctl sign -s /boot/vmlinuz-linux # Sign the kernel file. This is not necessary as we boot the UKI instead, but it also doesn't hurt.
+sudo sbctl verify # Verify that the above files have been correctly signed
 sbctl status # Verify that sbctl is correctly installed and that Setup Mode is now disabled
 ```
 

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -339,6 +339,7 @@ sudo sbctl sign -s /boot/EFI/BOOT/BOOTX64.EFI # Sign the fallback boot loader
 sudo sbctl sign -s /boot/vmlinuz-linux # Sign the kernel file. This is not necessary as we boot the UKI instead, but it also doesn't hurt.
 sudo sbctl verify # Verify that the above files have been correctly signed
 sbctl status # Verify that sbctl is correctly installed and that Setup Mode is now disabled
+sudo bootctl update # Force the update of the boot loader, just in case
 ```
 
 ### Enable Secure Boot


### PR DESCRIPTION
Add the signing of the `/boot/EFI/systemd/systemd-bootx64.efi` file (in addition of the already signed `/usr/lib/systemd/boot/efi/systemd-bootx64.efi.signed` file). This shouldn't be necessary usually but for some reason, it prevented a "Secure Boot violation" issue on *some of* my PCs.

Also add the signing of the `vmlinuz` kernel file (which is definitely not necessary since we boot the UKI instead, but it also doesn't hurt) and force the update of the bootloader after the `sbctl` setup, just in case.