### PR TITLE
Replace mlocate with plocate

### DIFF
--- a/Arch-Linux/Sway.md
+++ b/Arch-Linux/Sway.md
@@ -103,7 +103,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mlocate mpv noto-fonts-emoji powerline-fonts protonmail-bridge rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer wl-clip-persist xorg-xwayland yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc plocate mpv noto-fonts-emoji powerline-fonts protonmail-bridge rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer wl-clip-persist xorg-xwayland yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
 paru -S arch-update firefox-pwa onlyoffice-bin ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts qt6-wayland ttf-dejavu xdg-utils wofi #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service #Start and enable timers and services

--- a/Arch-Linux/Sway.md
+++ b/Arch-Linux/Sway.md
@@ -103,7 +103,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc plocate mpv noto-fonts-emoji powerline-fonts protonmail-bridge rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer wl-clip-persist xorg-xwayland yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mpv noto-fonts-emoji plocate powerline-fonts protonmail-bridge rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer wl-clip-persist xorg-xwayland yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
 paru -S arch-update firefox-pwa onlyoffice-bin ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts qt6-wayland ttf-dejavu xdg-utils wofi #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service #Start and enable timers and services

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -123,7 +123,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mlocate mpv noto-fonts-emoji powerline-fonts protonmail-bridge rofi rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc plocate mpv noto-fonts-emoji powerline-fonts protonmail-bridge rofi rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
 paru -S arch-update firefox-pwa onlyoffice-bin pa-applet-git ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service #Start and enable timers and services

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -123,7 +123,7 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc plocate mpv noto-fonts-emoji powerline-fonts protonmail-bridge rofi rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
+sudo pacman -S ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mpv noto-fonts-emoji plocate powerline-fonts protonmail-bridge rofi rsync speedcrunch steam systray-x thunderbird tmux ttf-font-awesome virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler #Main packages from Arch repos
 paru -S arch-update firefox-pwa onlyoffice-bin pa-applet-git ventoy-bin zaman #Main packages from the AUR
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu xdg-utils #Optional dependencies that I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service #Start and enable timers and services

--- a/Gentoo/i3.md
+++ b/Gentoo/i3.md
@@ -107,7 +107,7 @@ To enable flathub repo: `flatpak remote-add --if-not-exists flathub https://flat
 - powerline-fonts
 - zathura
 - zathura-pdf-poppler
-- mlocate
+- plocate
 - htop
 - fastfetch
 - yubico-piv-tool

--- a/WSL/Arch-Linux.md
+++ b/WSL/Arch-Linux.md
@@ -51,7 +51,7 @@ sudo vi /etc/pacman.conf
 
 ```bash
 sudo pacman -Syu #Update our system
-sudo pacman -S base-devel man bash-completion openssh inetutils dnsutils traceroute rsync zip unzip diffutils git tmux mlocate htop fastfetch docker distrobox pacman-contrib codespell #Install my needed packages. DO NOT INSTALL "fakeroot" (https://github.com/yuk7/ArchWSL/issues/3)
+sudo pacman -S base-devel man bash-completion openssh inetutils dnsutils traceroute rsync zip unzip diffutils git tmux plocate htop fastfetch docker distrobox pacman-contrib codespell #Install my needed packages. DO NOT INSTALL "fakeroot" (https://github.com/yuk7/ArchWSL/issues/3)
 cd /tmp #Change directory to tmp to download and install AUR support
 git clone https://aur.archlinux.org/paru.git #Download "paru" install sources
 cd paru #Change directory to "paru" install sources directory

--- a/WSL/Debian.md
+++ b/WSL/Debian.md
@@ -29,7 +29,7 @@ sudo vi /etc/wsl.conf
 ### Install my needed packages
 
 ```bash
-sudo apt install vim curl man bash-completion openssh-server inetutils-tools dnsutils traceroute rsync zip unzip diffutils git tmux mlocate htop neofetch codespell
+sudo apt install vim curl man bash-completion openssh-server inetutils-tools dnsutils traceroute rsync zip unzip diffutils git tmux plocate htop neofetch codespell
 curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo sh #Install distrobox
 sudo apt remove docker docker-engine docker.io #Install Docker
 sudo apt install apt-transport-https ca-certificates curl gnupg lsb-release


### PR DESCRIPTION
mlocate is very much an abandoned project, while plocate is a modern implementation with a faster database implementation along with io_uring support.

See https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/6Q2OBF3VPAWII66UIA43OEZFSRGUWS4E/