### PR TITLE
Remove MOZ_ENABLE_WAYLAND env var

### DIFF
--- a/Arch-Linux/Sway.md
+++ b/Arch-Linux/Sway.md
@@ -28,7 +28,6 @@ vim ~/.bash_profile
 > > export XDG_SESSION_TYPE=wayland  
 > > export QT_QPA_PLATFORM=wayland  
 > > export SDL_VIDEODRIVER=wayland  
-> > export MOZ_ENABLE_WAYLAND=1  
 > > exec sway  
 >
 > fi


### PR DESCRIPTION
This is not necessary anymore, Firefox uses Wayland by default now See https://wiki.archlinux.org/title/Firefox#Wayland