### PR TITLE
Add system-ukify to build UKI

### DIFF
--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -196,6 +196,7 @@ fallback_options="-S autodetect"
 
 ```bash
 mkdir -p /boot/EFI/Linux # Make sure the directory for the UKIs exists
+pacman -S --asdeps systemd-ukify # Install systemd-ukify to build / assemble the UKI
 mkinitcpio -P # Build the UKIs
 rm /boot/initramfs-*.img # Remove initramfs leftover images
 ```


### PR DESCRIPTION
`mkinitcpio` looks for `ukify` to build & assemble the UKI by default and only fallbacks to its own implementation if it isn't found.

> 16:37  Well yes, systemd keeps adding advanced features to UKIs and mkinitcpio is not going to reimplement them
> 16:38  the stub is used with a objcopy call that wraps several sections. And doing all of the measured boot/TPM stuff is just not going to be feasible to keep up with
> 16:38  better to rely on standardized tooling