### PR TITLE
Switch from the firefox-pwa AUR package to the firefoxpwa [extra] package

### DIFF
--- a/Arch-Linux/Sway.md
+++ b/Arch-Linux/Sway.md
@@ -141,8 +141,8 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S capitaine-cursors ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mpv mumble noto-fonts-emoji orchis-theme plocate powerline-fonts protonmail-bridge rsync speedcrunch steam systray-x tela-circle-icon-theme-blue thunderbird tmux ttf-font-awesome vim-devicons vim-nerdtree virt-viewer wl-clip-persist xorg-xwayland yubico-piv-tool zathura zathura-pdf-poppler
-paru -S arch-update firefox-pwa nerdtree-git-plugin-git onlyoffice-bin ventoy-bin zaman
+sudo pacman -S capitaine-cursors ccid discord distrobox docker fastfetch firefox firefoxpwa firejail htop keepassxc mpv mumble noto-fonts-emoji orchis-theme plocate powerline-fonts protonmail-bridge rsync speedcrunch steam systray-x tela-circle-icon-theme-blue thunderbird tmux ttf-font-awesome vim-devicons vim-nerdtree virt-viewer wl-clip-persist xorg-xwayland yubico-piv-tool zathura zathura-pdf-poppler
+paru -S arch-update nerdtree-git-plugin-git onlyoffice-bin ventoy-bin zaman
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts qt6-wayland ttf-dejavu ttf-nerd-fonts-symbols xdg-utils wofi # Optional dependencies I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service
 sudo systemctl enable --now apparmor docker pcscd

--- a/Arch-Linux/i3.md
+++ b/Arch-Linux/i3.md
@@ -134,8 +134,8 @@ sudo vim /etc/fstab
 - Main packages:
 
 ```bash
-sudo pacman -S capitaine-cursors ccid discord distrobox docker fastfetch firefox firejail htop keepassxc mpv mumble noto-fonts-emoji orchis-theme plocate powerline-fonts protonmail-bridge rofi rsync speedcrunch steam systray-x tela-circle-icon-theme-blue thunderbird tmux ttf-font-awesome vim-devicons vim-nerdtree virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler
-paru -S arch-update firefox-pwa nerdtree-git-plugin-git onlyoffice-bin pa-applet-git ventoy-bin zaman
+sudo pacman -S capitaine-cursors ccid discord distrobox docker fastfetch firefox firefoxpwa firejail htop keepassxc mpv mumble noto-fonts-emoji orchis-theme plocate powerline-fonts protonmail-bridge rofi rsync speedcrunch steam systray-x tela-circle-icon-theme-blue thunderbird tmux ttf-font-awesome vim-devicons vim-nerdtree virt-viewer xclip xorg-xhost yubico-piv-tool zathura zathura-pdf-poppler
+paru -S arch-update nerdtree-git-plugin-git onlyoffice-bin pa-applet-git ventoy-bin zaman
 sudo pacman -S --asdeps gnome-keyring gnu-free-fonts ttf-dejavu ttf-nerd-fonts-symbols xdg-utils # Optional dependencies I need for the above packages
 systemctl --user enable --now arch-update.timer ssh-agent.service
 sudo systemctl enable --now apparmor docker pcscd


### PR DESCRIPTION
firefoxpwa is now [available in [extra]](https://archlinux.org/packages/extra/x86_64/firefoxpwa/)