### PR TITLE
Use paccache.service environment file to pass extra arguments

### DIFF
--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -239,24 +239,25 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting all cached versions of installed and uninstalled packages, except for the most recent three.  
-You can launch it manually by running `paccache -r`.
-
-To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
+To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 ```bash
 sudo systemctl enable --now paccache.timer
 ```
 
-I personally modify the associated `paccache` systemd service to also delete uninstalled packages from cache:
+I personally add extra arguments to `paccache` to also delete every versions of uninstalled packages from the cache via the `/etc/conf.d/pacman-contrib` environment file for the systemd service:
 
 ```bash
-sudo systemctl edit paccache.service
+sudo vim /etc/conf.d/pacman-contrib
 ```
 
-> [Service]  
-> ExecStart=  
-> ExecStart=/bin/bash -c 'paccache -ruk0 && paccache -r'
+> [...]  
+> PACCACHE_ARGS=-ruk0
+
+```bash
+sudo systemctl daemon-reload
+```
 
 ## Enable fstrim (for SSDs only - optional)
 

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -278,24 +278,25 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting all cached versions of installed and uninstalled packages, except for the most recent three.  
-You can launch it manually by running `paccache -r`.
-
-To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
+To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 ```bash
 sudo systemctl enable --now paccache.timer
 ```
 
-I personally modify the associated `paccache` systemd service to also delete uninstalled packages from cache:
+I personally add extra arguments to `paccache` to also delete every versions of uninstalled packages from the cache via the `/etc/conf.d/pacman-contrib` environment file for the systemd service:
 
 ```bash
-sudo systemctl edit paccache.service
+sudo vim /etc/conf.d/pacman-contrib
 ```
 
-> [Service]  
-> ExecStart=  
-> ExecStart=/bin/bash -c 'paccache -ruk0 && paccache -r'
+> [...]  
+> PACCACHE_ARGS=-ruk0
+
+```bash
+sudo systemctl daemon-reload
+```
 
 ## Enable fstrim (for SSDs only - optional)
 


### PR DESCRIPTION
Use the new `/etc/conf.d/pacman-contrib` environment file (introduced in https://gitlab.archlinux.org/pacman/pacman-contrib/-/merge_requests/53) to pass extra arguments to `paccache.service` instead of overriding it completely.