### PR TITLE
Revert "Use paccache.service environment file to pass extra arguments (#270)"

### DIFF
--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -239,8 +239,8 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting all cached versions of installed and uninstalled packages, except for the most recent three.  
-You can launch it manually by running `paccache -r`.
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.
+To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
@@ -256,7 +256,7 @@ sudo systemctl edit paccache.service
 
 > [Service]  
 > ExecStart=  
-> ExecStart=/bin/bash -c 'paccache -ruk0 && paccache -r'
+> ExecStart=/bin/bash -c 'paccache -r && paccache -ruk0'
 
 ## Enable fstrim (for SSDs only - optional)
 

--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -239,7 +239,7 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
 To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:

--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -242,8 +242,6 @@ sudo firewall-cmd --reload # Apply changes
 The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
 To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
-To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
-
 ```bash
 sudo systemctl enable --now paccache.timer
 ```

--- a/Arch-Linux/Base_installation.md
+++ b/Arch-Linux/Base_installation.md
@@ -239,25 +239,24 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
-To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting all cached versions of installed and uninstalled packages, except for the most recent three.  
+You can launch it manually by running `paccache -r`.
+
+To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 ```bash
 sudo systemctl enable --now paccache.timer
 ```
 
-I personally add extra arguments to `paccache` to also delete every versions of uninstalled packages from the cache via the `/etc/conf.d/pacman-contrib` environment file for the systemd service:
+I personally modify the associated `paccache` systemd service to also delete uninstalled packages from cache:
 
 ```bash
-sudo vim /etc/conf.d/pacman-contrib
+sudo systemctl edit paccache.service
 ```
 
-> [...]  
-> PACCACHE_ARGS=-ruk0
-
-```bash
-sudo systemctl daemon-reload
-```
+> [Service]  
+> ExecStart=  
+> ExecStart=/bin/bash -c 'paccache -ruk0 && paccache -r'
 
 ## Enable fstrim (for SSDs only - optional)
 

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -278,25 +278,24 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
-To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting all cached versions of installed and uninstalled packages, except for the most recent three.  
+You can launch it manually by running `paccache -r`.
+
+To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 ```bash
 sudo systemctl enable --now paccache.timer
 ```
 
-I personally add extra arguments to `paccache` to also delete every versions of uninstalled packages from the cache via the `/etc/conf.d/pacman-contrib` environment file for the systemd service:
+I personally modify the associated `paccache` systemd service to also delete uninstalled packages from cache:
 
 ```bash
-sudo vim /etc/conf.d/pacman-contrib
+sudo systemctl edit paccache.service
 ```
 
-> [...]  
-> PACCACHE_ARGS=-ruk0
-
-```bash
-sudo systemctl daemon-reload
-```
+> [Service]  
+> ExecStart=  
+> ExecStart=/bin/bash -c 'paccache -ruk0 && paccache -r'
 
 ## Enable fstrim (for SSDs only - optional)
 

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -278,7 +278,7 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
 To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -281,8 +281,6 @@ sudo firewall-cmd --reload # Apply changes
 The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.  
 To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
-To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
-
 ```bash
 sudo systemctl enable --now paccache.timer
 ```

--- a/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
+++ b/Arch-Linux/Base_installation_with_disk_encryption_UKI_and_Secure_Boot.md
@@ -278,8 +278,8 @@ sudo firewall-cmd --reload # Apply changes
 
 ## Enable paccache (automatic cleaning of pacman cache)
 
-The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting all cached versions of installed and uninstalled packages, except for the most recent three.  
-You can launch it manually by running `paccache -r`.
+The `pacman-contrib` package provides the `paccache` script which cleans the `pacman` cache by deleting old cached packages versions.
+To run `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
 To launch `paccache` automatically on a weekly basis, enable the associated systemd timer:
 
@@ -295,7 +295,7 @@ sudo systemctl edit paccache.service
 
 > [Service]  
 > ExecStart=  
-> ExecStart=/bin/bash -c 'paccache -ruk0 && paccache -r'
+> ExecStart=/bin/bash -c 'paccache -r && paccache -ruk0'
 
 ## Enable fstrim (for SSDs only - optional)
 


### PR DESCRIPTION
Turns out `paccache` doesn't accept the same argument multiple time (e.g. `-d` or `-r`), only the last one is take into consideration.